### PR TITLE
license in README + demo shiny app

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2018 Genentech, Inc.
+Copyright 2019 Genentech, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Our package provides a set of functions to enhance your ggplots with eye-pleasin
 ![plot with tooltips](inst/example/ggtips.png?raw=true)
 
 
+[Demo shiny app](https://jcubic.shinyapps.io/ggtips/)
+
 ### Installation
 
 To install ggtips, use devtools:
@@ -46,3 +48,10 @@ case with the Windows operating system that have no Hyper-V enabled. You can fin
 If your Docker setup is using *docker-machine*, you can find it's IP using command `docker-machine ip`, then use the `http://{docker machine IP}:3838` address to connect to demo session. 
 
 See [Docker setup tutorial](https://docs.docker.com/get-started) to learn more about configuring Docker and [Docker Machine Documentation](https://docs.docker.com/machine/get-started/) to learn about *docker-machine* itself.
+
+
+## License
+
+Copyright 2019 Genentech, Inc.
+
+Released under Genentech Open License


### PR DESCRIPTION
As in title, hosted shiny app same as in example but with fancy GitHub ribbon. (and found bug needed to overwrite svglite svg css to make it work).