### PR TITLE
Fixed NA values when some panel is empty

### DIFF
--- a/R/grobs.R
+++ b/R/grobs.R
@@ -41,7 +41,7 @@ assignLayoutNamesToPanels <- function(gtree) {
   panelNums <- as.integer(gsub("^panel-([0-9]+).*$", "\\1", grobNames))
   panels <- c()
   panels[panelNums] <- layoutNames
-  panels
+  panels[!is.na(panels)]
 }
 
 #' Name to grob


### PR DESCRIPTION
Reproduction of the issue: ggplot object with a facet_wrap geometry, at least 3 panels, the middle one removed on a grob stage. The `assignLayoutNamesToPanels` function produces the following output: 
```"panel-1-1" NA          "panel-3-1"```

The output is the origin of the error in `nameToGrob` function:
```Error in [[: attempt to select less than one element in get1index```

As far as I can tell my change is not breaking anything in the package. I checked unit tests and the demo app. 