### PR TITLE
Enable polygon points for tooltips

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,8 @@ Imports:
     rlang,
     plyr,
     jsonlite,
-    htmltools
+    htmltools,
+    stringi
 RoxygenNote: 6.1.1
 Suggests:
     testthat,

--- a/inst/ggtips/ggtips.js
+++ b/inst/ggtips/ggtips.js
@@ -58,7 +58,8 @@ if (typeof jQuery === 'undefined') {
                             'rect:size(' + settings.size + ')',
                             'line:size(' + settings.size + ')' + css,
                             'line:size(' + settings.size + ', 0)' + css,
-                            'polyline:diamond:size(' + settings.size + ')'
+                            'polyline:diamond:size(' + settings.size + ')',
+                            'polygon:size(' + settings.size + ')'
                             ].join(', ');
 
             container.proximity('unbind').proximity(selector, {
@@ -167,7 +168,7 @@ if (typeof jQuery === 'undefined') {
                 point.coordX /= v.width;
                 point.coordY /= v.height;
                 return point;
-            } else if ($e.is('rect,line,:diamond')) {
+            } else if ($e.is('rect,line,:diamond,polygon')) {
                 var box = $e[0].getBBox();
                 cx = box.x + (box.width / 2);
                 cy = box.y + (box.height / 2);


### PR DESCRIPTION
Polygon-type ggplot2 points, like filled squares (shape 15), triangles (shape 17) or diamonds (shape 18) are not available for ggtips. This small change enables them.