### PR TITLE
add contributors #28

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ about configuring Docker and
 [Docker Machine Documentation](https://docs.docker.com/machine/get-started/)
 to learn about *docker-machine* itself.
 
+## Contributors
+<!-- CONTRIBUTORS-START -->
+* [Paweł Piątkowski](https://github.com/cosi1)
+* [Jakub T. Jankiewicz](https://github.com/jcubic)
+* [Marcin Kamianowski](https://github.com/marcin-kam)
+* [Michał Jakubczak](https://github.com/mjakubczak)
+* Michal Bartczak
+<!-- CONTRIBUTORS-END -->
 
 ## License
 

--- a/inst/ggtips/ggtips.js
+++ b/inst/ggtips/ggtips.js
@@ -30,7 +30,7 @@ if (typeof jQuery === 'undefined') {
 }
 
 (function($) {
-    
+
     // -------------------------------------------------------------------------
     // :: GGPlot Tooltips
     // -------------------------------------------------------------------------
@@ -51,6 +51,7 @@ if (typeof jQuery === 'undefined') {
             }
             var $container = tooltip.closest('.shiny-html-output')
                 .addClass('ggtips-plot');
+
             if (!$container.length) {
                 warn('GGTips: Invalid Container: no parent with shiny-html-output ' +
                      'class found');


### PR DESCRIPTION
Add list of contributors unfortunately I was not able to do this automatically using  GitHub API like in my other repo, because not all users commit with their GitHub email.

![contributors](https://user-images.githubusercontent.com/280241/81218173-166d6080-8fde-11ea-8744-6393ef7ada1f.png)

So I've added them by hand, and no avatars. just username and link to his profile if he have one.