### PR TITLE
fix getBBox in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.3.3
 ### Bugs
 * fix tooltip offset with scrollbar on content
+* fix issue on Firefox [#36](https://github.com/Roche/ggtips/issues/36)
 
 ## 0.3.2
 ### Bugs

--- a/inst/ggtips/ggtips.js
+++ b/inst/ggtips/ggtips.js
@@ -417,6 +417,9 @@ if (typeof jQuery === 'undefined') {
             element = $(element);
             var spec = meta[3].split(/\s*,\s*/).map(Number);
             var rect = element[0].getBoundingClientRect();
+            if (rect.width === 0 && rect.height === 0) {
+                return false;
+            }
             if (spec.length === 1) {
                 return rect.width < spec[0] && rect.height < spec[0];
             } else {


### PR DESCRIPTION
There problem was that proximity using size was founding rec that have 0 width and height that was throwing
exception in Firefox. It was working fine in Chrome

Fix #36