### PR TITLE
Fix for missing plot data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,8 @@ Imports:
     plyr,
     jsonlite,
     htmltools,
-    stringi
+    stringi,
+    dplyr
 RoxygenNote: 6.1.1
 Suggests:
     testthat,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,8 +25,7 @@ Imports:
     plyr,
     jsonlite,
     htmltools,
-    stringi,
-    dplyr
+    stringi
 RoxygenNote: 6.1.1
 Suggests:
     testthat,

--- a/R/contents.R
+++ b/R/contents.R
@@ -264,6 +264,20 @@ roundValues <- function(data) {
   })
 }
 
+#' Remove rows with NA coordinates
+#' 
+removeRowsWithNA <- function(data, mapping) {
+  mapply(
+    FUN = function(df, map){
+      # NAs transformed to characters in roundValues
+      dplyr::filter_at(df, dplyr::vars(!!map$x, !!map$y), ~ . != "NA") 
+    },
+    data,
+    mapping,
+    SIMPLIFY = FALSE
+  )
+}
+
 #'  Get data for tooltip contents
 #'
 getTooltipData <- function(plot, built, varDict, plotScales, callback) {
@@ -273,6 +287,7 @@ getTooltipData <- function(plot, built, varDict, plotScales, callback) {
   data <- roundValues(data)
   data <- unmapAes(data, mapping = mapping, plot = plot)
   data <- addCustomContents(data, callback = callback)
+  data <- removeRowsWithNA(data, mapping) # must be executed after addCustomContents
   lapply(data, getNamesFromVarDict, varDict = varDict, mapping = mapping)
 }
 

--- a/R/contents.R
+++ b/R/contents.R
@@ -270,7 +270,7 @@ removeRowsWithNA <- function(data, mapping) {
   mapply(
     FUN = function(df, map){
       # NAs transformed to characters in roundValues
-      dplyr::filter_at(df, dplyr::vars(!!map$x, !!map$y), ~ . != "NA") 
+      df[df[[map$x]] != "NA" & df[[map$y]] != "NA", ]
     },
     data,
     mapping,

--- a/R/misc.R
+++ b/R/misc.R
@@ -128,7 +128,7 @@ splitLongWords <- function(words, width, separators = "[,;:/\\?\\!\\-\\%]") {
           breaks <- seq(from = width, to = wordLen, by = width)
         }
         # if the last character is a separator, remove it from the list
-        if (dplyr::last(breaks) == wordLen) {
+        if (tail(breaks, 1) == wordLen) {
           breaks <- head(breaks, -1)
         }
         from <- c(1, breaks + 1)

--- a/tests/testthat/test_contents.R
+++ b/tests/testthat/test_contents.R
@@ -3,40 +3,64 @@ library(ggplot2)
 
 
 # Prepare input data ------------------------------------------------------
+prepareTestPlot <- function(df) {
+  testPlot <- ggplot(
+    data = df,
+    mapping = aes(x = Sepal.Width, y = Sepal.Length)
+  ) +
+    geom_point(mapping = aes(colour = Petal.Length)) +
+    facet_wrap(~ Species)
+  
+  list(
+    testPlot = testPlot,
+    testGrob = ggplot_build(testPlot)
+  )
+}
 
-testPlot <- ggplot(
-  data = iris,
-  mapping = aes(x = Sepal.Width, y = Sepal.Length)
-) +
-  geom_point(mapping = aes(colour = Petal.Length)) +
-  facet_wrap(~ Species)
+fullDataPlot <- prepareTestPlot(iris)
 
-testGrob <- ggplot_build(testPlot)
-
+df <- iris
+df[c(1, 143), "Sepal.Width"] <- NA
+df[c(64, 143), "Sepal.Length"] <- NA
+missingDataPlot <- prepareTestPlot(df)
 
 # Test routines -----------------------------------------------------------
 
 test_that("layers", {
-  aesth <- ggtips:::getLayerAesthetics(testPlot)
+  aesth <- ggtips:::getLayerAesthetics(fullDataPlot$testPlot)
   expect_gt(length(aesth), 0)
   expect_equal(aesth[[1]], list(x = "Sepal.Width", y = "Sepal.Length"))
-
-  expect_equal(ggtips:::getLayerGeom(testPlot$layers[[1]]), "points")
+  
+  expect_equal(ggtips:::getLayerGeom(fullDataPlot$testPlot$layers[[1]]), "points")
 })
 
 test_that("getTooltipData()", {
   varDict <- list(Species = "Species", Sepal.Length = "Sepal Length")
-  tooltipData <- ggtips:::getTooltipData(
-    plot = testPlot,
-    built = testGrob,
+  fullTooltipData <- ggtips:::getTooltipData(
+    plot = fullDataPlot$testPlot,
+    built = fullDataPlot$testGrob,
     varDict = varDict,
     plotScales = NULL,
     callback = NULL
   )
-  expect_is(tooltipData, "list")
-  expect_length(tooltipData, 1L)
-  tt <- tooltipData[[1]]
+  expect_is(fullTooltipData, "list")
+  expect_length(fullTooltipData, 1L)
+  tt <- fullTooltipData[[1]]
   expect_is(tt, "data.frame")
   expect_named(tt, as.character(varDict))
   expect_equal(nrow(tt), nrow(iris))
+  
+  missingTooltipData <- ggtips:::getTooltipData(
+    plot = missingDataPlot$testPlot,
+    built = missingDataPlot$testGrob,
+    varDict = varDict,
+    plotScales = NULL,
+    callback = NULL
+  )
+  expect_is(missingTooltipData, "list")
+  expect_length(missingTooltipData, 1L)
+  tt <- missingTooltipData[[1]]
+  expect_is(tt, "data.frame")
+  expect_named(tt, as.character(varDict))
+  expect_equal(nrow(tt), 147) # 3 rows with NAs
 })


### PR DESCRIPTION
ggplot ignores data rows with NA coordinates (x, y). The ggtips demo will produce an error for the following case:
```
# update the function in demo server.R and then run the demo
plotIris <- function(x_aes, y_aes) {
  d <- iris
  d[5, "Sepal.Length"] <- NA
  ggplot(data = d, mapping = aes_string(x = x_aes, y = y_aes)) +
    geom_point(mapping = aes(colour = Species)) +
    theme(legend.position = "bottom")
}
```
The error message:
```
Warning: Removed 1 rows containing missing values (geom_point).
Warning: Error in data.frame: arguments imply differing number of rows: 150, 149
```

This PR resolves this issue.