### PR TITLE
Extend the NA rows removal

### DIFF
--- a/inst/ggtips/ggtips.js
+++ b/inst/ggtips/ggtips.js
@@ -90,7 +90,6 @@ if (typeof jQuery === 'undefined') {
                         if (clientRect.width > 0 && clientRect.height > 0) {
                            p = $e[0].getBBox();
                            box = rect[0].getBBox();
-                           console.log(box);
                            var margin = 2; // 2px
                            if (p.x > box.x + box.width - margin ||
                               p.x < box.x + margin ||

--- a/inst/ggtips/ggtips.js
+++ b/inst/ggtips/ggtips.js
@@ -85,14 +85,19 @@ if (typeof jQuery === 'undefined') {
                     var root = $e.closest('svg');
                     var rect = root.find('[id^="' + clip + '"]').find('rect');
                     if (rect.length) {
-                        p = $e[0].getBBox();
-                        box = rect[0].getBBox();
-                        var margin = 2; // 2px
-                        if (p.x > box.x + box.width - margin ||
-                            p.x < box.x + margin ||
-                            p.y > box.y + box.height - margin ||
-                            p.y < box.y + margin) {
-                            return;
+                        var clientRect = rect[0].getBoundingClientRect();
+                        // Firefox has some issues with getting non-zero rect dimensions
+                        if (clientRect.width > 0 && clientRect.height > 0) {
+                           p = $e[0].getBBox();
+                           box = rect[0].getBBox();
+                           console.log(box);
+                           var margin = 2; // 2px
+                           if (p.x > box.x + box.width - margin ||
+                              p.x < box.x + margin ||
+                              p.y > box.y + box.height - margin ||
+                              p.y < box.y + margin) {
+                              return;
+                           }
                         }
                     }
                 }

--- a/tests/testthat/test_contents.R
+++ b/tests/testthat/test_contents.R
@@ -29,7 +29,7 @@ missingDataPlot <- prepareTestPlot(df)
 test_that("layers", {
   aesth <- ggtips:::getLayerAesthetics(fullDataPlot$testPlot)
   expect_gt(length(aesth), 0)
-  expect_equal(aesth[[1]], list(x = "Sepal.Width", y = "Sepal.Length"))
+  expect_equal(aesth[[1]], list(x = "Sepal.Width", y = "Sepal.Length", colour = "Petal.Length"))
   
   expect_equal(ggtips:::getLayerGeom(fullDataPlot$testPlot$layers[[1]]), "points")
 })


### PR DESCRIPTION
This extends the #40 by checking the presence of all aesthetics required by the layer. It also allows to use callback with an empty varDict and fixes the getLayerAesthetics function.