### PR TITLE
Avoid Rplots.pdf creation in the app dir

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -164,7 +164,14 @@ getSvgAndTooltipdata <- function(plot,
                                  customGrob = NULL,
                                  ...) {
   outfile <- tempfile(fileext = ".svg")
+  
+  currentDir <- getwd()
+  setwd(tempdir())
+  # arrangeGrob produces Rplots.pdf which may cause permission issue when run on shiny server
+  # to be more precise, ggplot2:::ggplot_gtable.ggplot_built is the origin of the issue
   grob <- gridExtra::arrangeGrob(`if`(is.null(customGrob), plot, customGrob))
+  setwd(currentDir)
+  
   data <- saveAndGetTooltips(
     plot = grob,
     ggPlotObj = plot,


### PR DESCRIPTION
For some reason, `ggplot2::ggplot_gtable()` function creates the Rplots.pdf file when called in non-interactive R sessions (Rscript, shiny server call etc). This function is called by `gridExtra::arrangeGrob()`.
The issue is that the file is being created in the app directory - which basically may be read-only from the shiny server perspective. As a result, the app may crash when trying to generate tooltips - write permissions not available.
This small fix changes the working directory to temp when generating a grob from a plot (and restores it afterwords).