### PR TITLE
Fix for aes names

### DIFF
--- a/tests/testthat/test_contents.R
+++ b/tests/testthat/test_contents.R
@@ -95,13 +95,15 @@ test_that("getTooltipData()", {
 test_that("Custom case", {
   data <- mpg
   data[["class"]] <- factor(data[["class"]])
+  data[124, "cyl"] <- NA
   
   p <- ggplot(
     data = data,
-    mapping = aes(x = displ, y = cty)
+    mapping = aes(x = displ, y = cty, colour = cyl)
   ) + 
     geom_point() + 
     geom_line() + 
+    geom_hline(yintercept = 20) + 
     facet_wrap(~ class)
   
   varDict <- list(


### PR DESCRIPTION
Fix for the following example:
```library(ggplot2)
library(dplyr)
p <- ggplot(
  data = mpg %>% dplyr::mutate(class = factor(class)),
  mapping = aes(x = displ, y = cty)
) + 
  geom_point() + 
  geom_line() + 
  facet_wrap(~ class)

varDict <- list(
  displ = "Display",
  cty = "Cty",
  class = "Class"
)

data <- ggtips::getSvgAndTooltipdata(
  plot = p,
  varDict = varDict,
  width = 300,
  height = 400,
  plotScales = list(x = "identity", y = "identity"),
  addAttributes = TRUE
)
```