### PR TITLE
Avoid lazy load of plot data

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -171,6 +171,10 @@ getSvgAndTooltipdata <- function(plot,
                                  ...) {
   outfile <- tempfile(fileext = ".svg")
 
+  # avoid lazy eval to use correct directory
+  plot <- plot
+  customGrob <- customGrob
+  
   currentDir <- getwd()
   setwd(tempdir())
   # arrangeGrob produces Rplots.pdf which may cause permission issue when run on shiny server


### PR DESCRIPTION
Temporary directory is used during plot expression evaluation