### PR TITLE
Exclude groups names of groups that are out of plot range

### DIFF
--- a/R/contents.R
+++ b/R/contents.R
@@ -90,13 +90,15 @@ getLayerGeom <- function(layer) {
 unmapFactors <- function(df, origin) {
   # Order factor levels in the original data frame
   origin <- freezeFactorLevels(origin)
+  # Include only matching rows
+  origin <- origin[rownames(df),]
   # Select only factor variables
   factors <- Filter(
     function(name) { is.factor(origin[[name]]) },
     names(origin)
   )
   for (name in factors) {
-    origColumn <- origin[[name]]
+    origColumn <- droplevels(origin[[name]])
     if (name %in% names(df)) {
       # Map values in the column to the original values
       column <- df[[name]]

--- a/README.md
+++ b/README.md
@@ -133,4 +133,5 @@ to learn about *docker-machine* itself.
 * [Michał Jakubczak](https://github.com/mjakubczak)
 * [Ewa Ostrowiecka](https://github.com/ewaostrowiecka)
 * Michal Bartczak
+* [Adam Golubowski](https://github.com/adamgolubowski)
 <!-- CONTRIBUTORS-END -->


### PR DESCRIPTION
When limiting range of plot axis there may be situation that some items on plot are outside of selected range and so they are not visible. ggtips incorrectly assigned levels in tooltip data. When item was out of plot range then it was correctly removed from data but its level was assigned to the next visible element in data. As a result incorrect labels were visible on tooltips.  