### PR TITLE
Use plot layer data as source for factor levels for tooltip data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ggtips
 Type: Package
 Title: Interactive Tooltips for ggplots
-Version: 0.3.4
+Version: 0.3.5
 Authors@R: c(person("Jakub", "Jankiewicz", role = "aut",
                     email = "jakub.jankiewicz@contractors.roche.com"),
              person("Michal", "Jakubczak", role = "ctb",


### PR DESCRIPTION
 `plot$data` in `unmapAes` function was source of levels mapped to tooltip data. I changed the program to use plot layers data when available. If plot layer data is a ggplot2 waiver it defaults to `plot$data`. 
There may be a situation when `plot$data` does not easily match tooltip data. Change introduced in this PR attempts to provide more relevant data for tooltip mapping.