### PR TITLE
fix tooltip error when data is empty list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.3.4
+### Features
+* NULL `varDict` turns off rendering tooltips
+
+### Bugs
+* Handling NA values
+* Flipped coords
+* Plots with custom ranges
+* Multi-faceted trellises
+
 ## 0.3.3
 * Updated MIT license
 

--- a/R/main.R
+++ b/R/main.R
@@ -106,7 +106,7 @@ htmlWithGivenTooltips <- function(svg,
                                   height = NA,
                                   width = NA,
                                   point.size = 10) {
-  if (is.null(data)) {
+  if (length(data) == 0) {
     return(shiny::HTML(svg))
   }
   data <- list(


### PR DESCRIPTION
It seems that on barplot, that we have in our application, the data is an empty list not null. It throws errors when it finds small rectangles from small bars on the plot.