### PR TITLE
remove top white rect in svg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.5
+### Features
+* fix handling of transparent plots
+### Bugs
+* fix error when tooltip function return empty list
+
 ## 0.3.4
 ### Features
 * NULL `varDict` turns off rendering tooltips

--- a/R/main.R
+++ b/R/main.R
@@ -174,7 +174,7 @@ getSvgAndTooltipdata <- function(plot,
   # avoid lazy eval to use correct directory
   plot <- plot
   customGrob <- customGrob
-  
+
   currentDir <- getwd()
   setwd(tempdir())
   # arrangeGrob produces Rplots.pdf which may cause permission issue when run on shiny server
@@ -189,7 +189,9 @@ getSvgAndTooltipdata <- function(plot,
       dpi = dpi,
       width = width,
       height = height,
-      limitsize = FALSE
+      limitsize = FALSE,
+      bg = "transparent",
+      ...
     )
     NULL
   } else {
@@ -205,6 +207,7 @@ getSvgAndTooltipdata <- function(plot,
       width = width,
       height = height,
       limitsize = FALSE,
+      bg = "transparent",
       ...
     )
   }

--- a/R/tooltips.R
+++ b/R/tooltips.R
@@ -43,14 +43,14 @@
 #' values in tooltips. If NULL (default), values are displayed "as is".
 #' @param callback Callback function for adding custom content to the tooltips
 #' (see the example app).
-#' @param addAttributes Logical parameter determinig whether extra geom 
+#' @param addAttributes Logical parameter determinig whether extra geom
 #' attributes should be add to tooltip object.
 #'
-getTooltips <- function(plot, 
-                        varDict, 
-                        plotScales, 
-                        g, 
-                        callback, 
+getTooltips <- function(plot,
+                        varDict,
+                        plotScales,
+                        g,
+                        callback,
                         addAttributes = FALSE) {
   gb <- ggplot2::ggplot_build(plot)
   tooltipData <- getTooltipData(
@@ -61,7 +61,7 @@ getTooltips <- function(plot,
     callback = callback
   )
   layoutNames <- assignLayoutNamesToPanels(g)
-  
+
   totalPlotSize <- getGrobSize(g)
   plotWidth <- totalPlotSize$width
   plotHeight <- totalPlotSize$height
@@ -123,12 +123,12 @@ getTooltips <- function(plot,
     simplify = FALSE,
     USE.NAMES = TRUE
   )
-  
+
   if (addAttributes) {
     attr(res, "colWidths") <- colWidths
     attr(res, "rowHeights") <- rowHeights
   }
-  
+
   res
 }
 
@@ -137,7 +137,7 @@ getTooltips <- function(plot,
 #' Wrapper for \link{ggsave}; after saving a plot, returns an HTML-formatted
 #' list of tooltip data (see \link{getTooltips}).
 #'
-#' @param plot ggplot object or customGrob, see "getSvgAndTooltipdata" for 
+#' @param plot ggplot object or customGrob, see "getSvgAndTooltipdata" for
 #' more details.
 #' @param g A gtable object compiled from the plot (see \link{arrangeGrob}).
 #' @param varDict Variable dictionary in the following format:
@@ -151,7 +151,7 @@ getTooltips <- function(plot,
 #' @param ggPlotObj optional, used if plot is a customGrob.
 #' @param callback Callback function for adding custom content to the tooltips
 #' (see the example app).
-#' @param addAttributes Logical parameter determinig whether extra geom 
+#' @param addAttributes Logical parameter determinig whether extra geom
 #' attributes should be add to tooltip object.
 #'
 #' @return A list.
@@ -161,11 +161,11 @@ saveAndGetTooltips <- ggplot2::ggsave
 formals(saveAndGetTooltips) <- c(
   formals(saveAndGetTooltips),
   alist(
-    varDict = , 
-    plotScales = , 
-    g = , 
-    ggPlotObj = NULL, 
-    callback = NULL, 
+    varDict = ,
+    plotScales = ,
+    g = ,
+    ggPlotObj = NULL,
+    callback = NULL,
     addAttributes = FALSE
   )
 )


### PR DESCRIPTION
By default, svgilite is adding an additional white rectangle to SVG so transparency added using GGPlot doesn't work.

See the last comment in https://github.com/r-lib/svglite/issues/41