### PR TITLE
don't set transparency by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.3.5
 ### Features
-* fix handling of transparent plots
+* Allow to set transparent plots
 ### Bugs
 * fix error when tooltip function return empty list
 

--- a/R/main.R
+++ b/R/main.R
@@ -190,7 +190,6 @@ getSvgAndTooltipdata <- function(plot,
       width = width,
       height = height,
       limitsize = FALSE,
-      bg = "transparent",
       ...
     )
     NULL
@@ -207,7 +206,6 @@ getSvgAndTooltipdata <- function(plot,
       width = width,
       height = height,
       limitsize = FALSE,
-      bg = "transparent",
       ...
     )
   }


### PR DESCRIPTION
It's better to leave transparency to the user (original version didn't have `...` for `ggplot2::ggsave`)