### PR TITLE
Add addAttributes parameter to getSvgAndTooltipdata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.6
+### Bugs
+* add addAttributes parameter to getSvgAndTooltipdata to fix unused argument errors
+
 ## 0.3.5
 ### Features
 * Allow to set transparent plots

--- a/R/main.R
+++ b/R/main.R
@@ -168,6 +168,7 @@ getSvgAndTooltipdata <- function(plot,
                                  width = NA,
                                  height = NA,
                                  customGrob = NULL,
+                                 addAttributes = FALSE,
                                  ...) {
   outfile <- tempfile(fileext = ".svg")
 
@@ -206,6 +207,7 @@ getSvgAndTooltipdata <- function(plot,
       width = width,
       height = height,
       limitsize = FALSE,
+      addAttributes = addAttributes,
       ...
     )
   }


### PR DESCRIPTION
Prevent unused argument error by adding `addAttibutes` parameter to `getSvgAndTooltipdata` and pass it explicitly to `saveAndGetTooltips`