### PR TITLE
DIVOS-8798: fix shrinking tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2
+### Bugs
+* fix shrinking tooltips
+
 ## 0.4.1
 ### Bugs
 * cleanup the events after rendering ggtips without tooltips

--- a/inst/ggtips/ggtips.css
+++ b/inst/ggtips/ggtips.css
@@ -21,7 +21,7 @@
   display: block;
   white-space: pre-wrap;
   word-break: break-all;
-  max-width: calc(var(--ggtips-width, 220) * 1px);
+  width: calc(var(--ggtips-width, 220) * 1px);
 }
 .ggtips-tooltip::before, .ggtips-tooltip::after {
   border: 5px solid var(--background, black);


### PR DESCRIPTION
There was issue when scrolling and moving cursor on top of the plot, where tooltips where shrinking.
I have no idea why there was `max-width` instead of just `width` it seems that this fixes the issue.