### PR TITLE
Warn user about invalid state of the tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.3
+### Bugs
+* fix handlig errors when SVG plot is replaced
+* make proximity event work only when there is ggtips-plot class
+
 ## 0.4.2
 ### Bugs
 * fix shrinking tooltips

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ggtips
 Type: Package
 Title: Interactive Tooltips for ggplots
-Version: 0.4.2
+Version: 0.4.3
 Authors@R: c(person("Jakub", "Jankiewicz", role = "aut",
                     email = "jakub.jankiewicz@contractors.roche.com"),
              person("Michal", "Jakubczak", role = "ctb",

--- a/README.md
+++ b/README.md
@@ -134,4 +134,5 @@ to learn about *docker-machine* itself.
 * [Ewa Ostrowiecka](https://github.com/ewaostrowiecka)
 * Michal Bartczak
 * [Adam Golubowski](https://github.com/adamgolubowski)
+* [Jakub Malecki](https://github.com/OliBravo)
 <!-- CONTRIBUTORS-END -->

--- a/inst/ggtips/ggtips.js
+++ b/inst/ggtips/ggtips.js
@@ -483,29 +483,34 @@ if (typeof jQuery === 'undefined') {
                 var closest;
                 // calculate distance to all elements matched by selector
                 // and find the closest
-                var distances = $elements.map(function() {
-                    if (this instanceof SVGPolygonElement) {
-                        var self = $(this);
-                        if (self.is('.large')) {
-                            var center = self.data('center');
-                            var points = self.data('points');
-                            var distance;
-                            if (isPointInPoly(points, point)) {
-                                distance = 0;
-                            } else {
-                                distance = outside;
+                try {
+                    var distances = $elements.map(function() {
+                        if (this instanceof SVGPolygonElement) {
+                            var self = $(this);
+                            if (self.is('.large')) {
+                                var center = self.data('center');
+                                var points = self.data('points');
+                                var distance;
+                                if (isPointInPoly(points, point)) {
+                                    distance = 0;
+                                } else {
+                                    distance = outside;
+                                }
+                                return {
+                                    distance: distance,
+                                    element: this
+                                };
                             }
-                            return {
-                                distance: distance,
-                                element: this
-                            };
                         }
-                    }
-                    return {
-                        distance: boxDistance(this, e.pageX, e.pageY),
-                        element: this
-                    };
-                }).get();
+                        return {
+                            distance: boxDistance(this, e.pageX, e.pageY),
+                            element: this
+                        };
+                    }).get();
+                } catch (e) {
+                    $this.proximity('unbind');
+                    throw e;
+                }
                 distances.forEach(function(data) {
                     if (!closest || data.distance < closest.distance) {
                         closest = data;

--- a/inst/ggtips/ggtips.js
+++ b/inst/ggtips/ggtips.js
@@ -700,6 +700,10 @@ if (typeof jQuery === 'undefined') {
         left = offset.left;
         top = offset.top;
         var box = el.data('box');
+        if (!box) {
+            throw new Error("ggtips: Invlaid state. If you don't use tooltips " +
+                            "please try to call ggtips('destroy') to remove the evennts");
+        }
         var width = box.width;
         var height = box.height;
         right = left + width;


### PR DESCRIPTION
@cosi1 this is the proper fix, so the user knows where to look if this error happens. If a box is undefined it means that there are no longer tooltips (there was rerender) on the plot, and this is probably the case when tooltips were added manually like in IDA.