### PR TITLE
Make tooltip distance tolerance setting as a parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0
+### Features
+* parametrize tooltip distance tolerance value
+
 ## 0.5.1
 ### Bugs
 * fix issue when plot changes the size

--- a/R/main.R
+++ b/R/main.R
@@ -60,6 +60,7 @@ renderWithTooltips <- function(plot,
                                width = NA,
                                height = NA,
                                customGrob = NULL,
+                               tolerance = 0.5,
                                ...) {
   if (!requireNamespace("shiny")) {
     stop("renderWithTooltips() requires Shiny")
@@ -84,7 +85,8 @@ renderWithTooltips <- function(plot,
       height = height,
       width = width,
       tooltip.width = tooltip.width,
-      point.size = point.size
+      point.size = point.size,
+      tolerance = tolerance
     )
   }, name = "func", eval.env = parent.frame(), quoted = FALSE)
 
@@ -157,7 +159,8 @@ htmlWithGivenTooltips <- function(svg,
                                   height = NA,
                                   width = NA,
                                   tooltip.width = "220px",
-                                  point.size = 10) {
+                                  point.size = 10,
+                                  tolerance = 0.05) {
   ggtips.arg <- if (length(data) == 0) {
     'unbind'
   } else {
@@ -165,7 +168,8 @@ htmlWithGivenTooltips <- function(svg,
       data = data,
       width = width,
       height = height,
-      size = point.size
+      size = point.size,
+      tolerance = tolerance
     )
   }
 
@@ -309,6 +313,7 @@ plotWithTooltips <- function(plot,
                              width = NA,
                              height = NA,
                              customGrob = NULL,
+                             tolerance = 0.05,
                              ...) {
   res <- ggtips::getSvgAndTooltipdata(
     plot = plot,
@@ -327,6 +332,7 @@ plotWithTooltips <- function(plot,
     data = res$data,
     height = height,
     width = width,
-    point.size = point.size
+    point.size = point.size,
+    tolerance = tolerance
   )
 }

--- a/inst/ggtips/ggtips.js
+++ b/inst/ggtips/ggtips.js
@@ -44,6 +44,7 @@ if (typeof jQuery === 'undefined') {
         }
         var settings = $.extend({
             size: 12,
+            tolerance: 0.05, 
             debug: false,
             data: {points: []}
         }, options);
@@ -111,10 +112,10 @@ if (typeof jQuery === 'undefined') {
                 if (settings.data.gTree) {
                     // Temporary for Pie-Charts
                     data_point = getSlicePoint($svg, point);
-                    p = findData(settings.data.gTree, data_point, 0.05);
+                    p = findData(settings.data.gTree, data_point, settings.tolerance);
                 } else {
                     data_point = getPoint($svg, point);
-                    p = findData(settings.data.points, data_point, 0.05);
+                    p = findData(settings.data.points, data_point, settings.tolerance);
                 }
                 if (settings.debug) {
                     e.target.style.stroke = '#000000';


### PR DESCRIPTION
When matching tooltip data to svg elements distance tolerance was hardcoded as `0.05`. I changed it to be passed as a parameter. In some cases the default `0.05` distance tolerance may be to big and tooltips may be displayed for shapes that are not in the plot area, e.g. circles in a legend. Changing tolerance to smaller value can fix the issue.