### PR TITLE
Handle case when there are no valid points for geom coordinates

### DIFF
--- a/R/grobs.R
+++ b/R/grobs.R
@@ -357,6 +357,10 @@ getGeomCoordsForGrob <- function(gtree,
     validX <- which(xVal >= 0 & xVal <= 1)
     validY <- which(yVal >= 0 & yVal <= 1)
     validPoints <- intersect(validX, validY)
+    
+    if (length(validPoints) == 0) {
+      return(NULL)
+    }
 
     geomGrob$x <- geomGrob$x[validPoints]
     geomGrob$y <- geomGrob$y[validPoints]


### PR DESCRIPTION
There are cases when there are no valid points when calculating grob coordinates. This caused an error. The change fixes this by returning NULL if no points are valid. 