### PR TITLE
Replace `devtools` with `remotes` in Dockerfile

### DIFF
--- a/inst/Dockerfile
+++ b/inst/Dockerfile
@@ -5,8 +5,8 @@ MAINTAINER Pawel Piatkowski <pawel.piatkowski@roche.com>
 RUN apt-get update && apt-get install -y libssl-dev libxml2-dev libcurl4-openssl-dev libcairo2-dev
 
 COPY . /tmp
-RUN R -e 'install.packages("devtools", dependencies = TRUE)'
-RUN R -e 'devtools::install_deps("/tmp", dependencies = TRUE)'
+RUN R -e 'install.packages("remotes", dependencies = TRUE)'
+RUN R -e 'remotes::install_deps("/tmp", dependencies = TRUE)'
 RUN R CMD INSTALL /tmp
 
 EXPOSE 3838


### PR DESCRIPTION
This would slim down the Docker image.