### PR TITLE
removeOutOfRangeData: treat NA as out of range

### DIFF
--- a/R/contents.R
+++ b/R/contents.R
@@ -247,11 +247,11 @@ removeOutOfRangeData <- function(data, plot, built) {
     range <- getRanges(plot, built)
 
     if (is(plot$coordinates, "CoordFlip") && isGgplot2()) {
-      d <- d[d$x >= min(range$y) & d$x <= max(range$y), ]
-      d <- d[d$y >= min(range$x) & d$y <= max(range$x), ]
+      d <- d[!is.na(d$x) & d$x >= min(range$y) & d$x <= max(range$y), ]
+      d <- d[!is.na(d$y) & d$y >= min(range$x) & d$y <= max(range$x), ]
     } else {
-      d <- d[d$x >= min(range$x) & d$x <= max(range$x), ]
-      d <- d[d$y >= min(range$y) & d$y <= max(range$y), ]
+      d <- d[!is.na(d$x) & d$x >= min(range$x) & d$x <= max(range$x), ]
+      d <- d[!is.na(d$y) & d$y >= min(range$y) & d$y <= max(range$y), ]
     }
 
     d


### PR DESCRIPTION
Hi,

I found a small bug that occurs when there are NA values in `x` or `y` mappings.

Consider the following app - it creates two plots, but for one of them (the bottom one), an `NA` value is added to the `x` mapping. 
```r
library(shiny)
library(ggtips)
library(ggplot2)

ui <- fluidPage(
    uiOutput(outputId = "myPlot"),
    uiOutput(outputId = "myPlotNA")
)

plotData <- function(addNA = TRUE) {
    data <- data.frame(x = c(0, 1, 2), y = c(0, 1, 2), zz = factor(c("A", "A", "B")))
    if(addNA) data[1,1] <- NA
    ggplot(data = data, mapping = aes_string(x = "x", y = "y")) +
        geom_point(mapping = aes(colour = zz)) 
}

server <- function(input, output) {

    output[["myPlot"]] <- renderWithTooltips(
        plot = plotData(FALSE),
        varDict =
            structure(
                list("zz"),
                names = c("zz")
            ),
        width = 3,
        height = 3,
        point.size = 20,
    )
    output[["myPlotNA"]] <- renderWithTooltips(
        plot = plotData(TRUE),
        varDict =
            structure(
                list("zz"),
                names = c("zz")
            ),
        width = 3,
        height = 3,
        point.size = 20,
    )
}

shinyApp(ui = ui, server = server)
```

And the output:
![image](https://user-images.githubusercontent.com/3474533/165484936-cc9e3d1f-12f9-407c-b655-40bd9f22afeb.png)
![image](https://user-images.githubusercontent.com/3474533/165485006-8c778c44-53ee-44b4-b2f2-a6cd59295365.png)

I've tracked the issue and found out that there's a problem in the `removeOutOfRangeData` function.
The data before applying the function:
```
   colour  x y PANEL group shape size fill alpha stroke
1 #F8766D NA 0     1     1    19  1.5   NA    NA    0.5
2 #F8766D  1 1     1     1    19  1.5   NA    NA    0.5
3 #00BFC4  2 2     1     2    19  1.5   NA    NA    0.5
```
After applying the function:
```
    colour  x  y PANEL group shape size fill alpha stroke
NA    <NA> NA NA  <NA>    NA    NA   NA   NA    NA     NA # <- this row causes the issue
2  #F8766D  1  1     1     1    19  1.5   NA    NA    0.5
3  #00BFC4  2  2     1     2    19  1.5   NA    NA    0.5
```
The real trouble happens in the `removeRowsWithNA` call, when this NA row is selected. I had been thinking that maybe it should be solved there, but then I thought: _Naaah, in the end the NA is out range value_, so I fixed the issue in the `removeOutOfRangeData` function.