### PR TITLE
unmapFactors: handle NA in the origColumn

### DIFF
--- a/R/contents.R
+++ b/R/contents.R
@@ -110,7 +110,9 @@ unmapFactors <- function(df, origin, plot, layerData) {
       # Map values in the column to the original values
       column <- df[[name]]
       asFactor <- factor(column, levels = unique(column))
-      df[[name]] <- levels(origColumn)[asFactor]
+      lvls <- levels(origColumn)
+      if(anyNA(origColumn)) lvls <- c(NA, lvls)
+      df[[name]] <- lvls[asFactor]
     } else {
       if (length(origColumn) == nrow(df)) {
         # Simply add the column from the original data frame


### PR DESCRIPTION
Hi,

I found another bug related to `NA`. Consider the following data set:
```
data
  x y   zz
1 0 0 <NA>
2 1 1    A
3 2 2    B
4 3 3    A
```
![image](https://user-images.githubusercontent.com/3474533/165717842-6225a2ad-31b6-4b8a-a9e0-13bef21c8cbe.png)

As you can see, `ggtips` shows wrong label compared to standard `ggplot2` output.

My diagnosis is that the issue is caused by the `unmapFactors`, which does not take into account NA level when mapping the colors back to the factor levels. 

*Important note!* I did not check the `unmapFactorsBarLayer`, so I don't know if it suffers from a similar issue.

Here's the code for the app used to reproduce this error:
```r
library(shiny)
library(ggtips)
library(ggplot2)

ui <- fluidPage(
    
    h3("ggplot2:"),
    plotOutput(outputId = "myPlot", width = 300, height = 300),
    h3("ggtips:"),
    uiOutput(outputId = "myPlotNA")
)

plotData <- function(addNA = TRUE) {
    data <- data.frame(x = c(0, 1, 2, 3), y = c(0, 1, 2, 3), zz = factor(c("A", "A", "B", "A")))
    if(addNA) {
        data[1,3] <- NA
    }
    ggplot(data = data, mapping = aes_string(x = "x", y = "y")) +
        geom_point(mapping = aes(colour = zz)) 
}

# Define server logic required to draw a histogram
server <- function(input, output) {

    output$myPlot <- renderPlot({
        plotData() + ggrepel::geom_label_repel(aes(label = zz))
    })
    output[["myPlotNA"]] <- renderWithTooltips(
        plot = plotData(TRUE),
        varDict =
            structure(
                list("zz"),
                names = c("zz")
            ),
        width = 3.5,
        height = 3.5,
        point.size = 20,
    )
}

# Run the application 
shinyApp(ui = ui, server = server)

```
